### PR TITLE
Support environment variables as a configuration source

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,9 @@ CNF-01 is a library that provides immutable configuration for Java projects. Imm
 == Features
 
 // List your project's features
-- Provides immutable configurations for configuration files / path properties (`PathConfiguration`)
+- Provides immutable configurations for:
+. configuration files / path properties (`PathConfiguration`)
+. environment variables (`EnvironmentConfiguration`)
 - Default configurations in case the provided configurations from a source are not found or are otherwise broken (`DefaultConfiguration`)
 
 == Limitations

--- a/src/main/java/com/teragrep/cnf_01/EnvironmentConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/EnvironmentConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * Teragrep Configuration Library for Java (cnf_01)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cnf_01;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Provides a deep copied immutable map of the system's environment variables.
+ */
+public final class EnvironmentConfiguration implements Configuration {
+
+    private final ImmutableMap<String, String> environment;
+
+    /**
+     * No parameter in constructor; uses System.getenv().
+     */
+    public EnvironmentConfiguration() {
+        this(System.getenv());
+    }
+
+    /**
+     * This constructor is only used in testing and therefore is package-private
+     * 
+     * @param environment system environment
+     */
+    EnvironmentConfiguration(final Map<String, String> environment) {
+        this.environment = new ImmutabilitySupportedMap<>(environment).toImmutableMap();
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+        return environment;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final EnvironmentConfiguration config = (EnvironmentConfiguration) o;
+        return environment.equals(config.environment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(environment);
+    }
+}

--- a/src/main/java/com/teragrep/cnf_01/EnvironmentConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/EnvironmentConfiguration.java
@@ -45,6 +45,9 @@
  */
 package com.teragrep.cnf_01;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -52,6 +55,8 @@ import java.util.Objects;
  * Provides a deep copied immutable map of the system's environment variables.
  */
 public final class EnvironmentConfiguration implements Configuration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentConfiguration.class);
 
     private final ImmutableMap<String, String> environment;
 
@@ -73,6 +78,9 @@ public final class EnvironmentConfiguration implements Configuration {
 
     @Override
     public Map<String, String> asMap() {
+        LOGGER.debug("Returning configuration map generated from environment variables.");
+        LOGGER.trace("Returning configuration map <[{}]>", environment);
+
         return environment;
     }
 

--- a/src/main/java/com/teragrep/cnf_01/ImmutableMap.java
+++ b/src/main/java/com/teragrep/cnf_01/ImmutableMap.java
@@ -189,6 +189,11 @@ public final class ImmutableMap<K, V> implements Map<K, V> {
     }
 
     @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;

--- a/src/test/java/com/teragrep/cnf_01/EnvironmentConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/EnvironmentConfigurationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Teragrep Configuration Library for Java (cnf_01)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.cnf_01;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvironmentConfigurationTest {
+
+    @Test
+    public void testEnvironment() {
+        EnvironmentConfiguration env = new EnvironmentConfiguration();
+        Map<String, String> map = env.asMap();
+
+        // Can't test environment variables reliably, just testing if the map has values.
+        Assertions.assertFalse(map.isEmpty());
+    }
+
+    @Test
+    public void testMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("foo", "bar");
+
+        EnvironmentConfiguration env = new EnvironmentConfiguration(map);
+        // modifying the original doesn't have effect on the result
+        map.put("bar", "foo");
+
+        Map<String, String> result = env.asMap();
+
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.containsKey("foo"));
+        Assertions.assertEquals("bar", result.get("foo"));
+    }
+
+    @Test
+    public void testEmptyMap() {
+        Map<String, String> map = new HashMap<>();
+        EnvironmentConfiguration env = new EnvironmentConfiguration(map);
+        // modifying the original doesn't have effect on the result
+        map.put("foo", "bar");
+
+        Map<String, String> result = env.asMap();
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testEqualsEnvironment() {
+        EnvironmentConfiguration env1 = new EnvironmentConfiguration();
+        EnvironmentConfiguration env2 = new EnvironmentConfiguration();
+
+        env1.asMap();
+
+        Assertions.assertEquals(env1, env2);
+    }
+
+    @Test
+    public void testEqualsMap() {
+        Map<String, String> map1 = new HashMap<>();
+        map1.put("foo", "bar");
+        Map<String, String> map2 = new HashMap<>();
+        map2.put("foo", "bar");
+
+        EnvironmentConfiguration env1 = new EnvironmentConfiguration(map1);
+        EnvironmentConfiguration env2 = new EnvironmentConfiguration(map2);
+
+        env1.asMap();
+
+        Assertions.assertEquals(env1, env2);
+    }
+
+    @Test
+    public void testNotEquals() {
+        Map<String, String> map = new HashMap<>();
+        map.put("foo", "bar");
+        EnvironmentConfiguration env1 = new EnvironmentConfiguration();
+        EnvironmentConfiguration env2 = new EnvironmentConfiguration(map);
+
+        Assertions.assertNotEquals(env1, env2);
+    }
+
+    @Test
+    public void testHashCode() {
+        Map<String, String> map1 = new HashMap<>();
+        map1.put("foo", "bar");
+        Map<String, String> map2 = new HashMap<>();
+        map2.put("foo", "bar");
+        EnvironmentConfiguration env1 = new EnvironmentConfiguration(map1);
+        EnvironmentConfiguration env2 = new EnvironmentConfiguration(map2);
+        EnvironmentConfiguration difEnv = new EnvironmentConfiguration();
+
+        Assertions.assertEquals(env1.hashCode(), env2.hashCode());
+        Assertions.assertNotEquals(env1.hashCode(), difEnv.hashCode());
+    }
+
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier.forClass(EnvironmentConfiguration.class).withNonnullFields("environment").verify();
+    }
+}


### PR DESCRIPTION
Fixes #8 .

Adds support for environment variables. Same thing as with System Properties, it can't really fail so it doesn't throw an exception in asMap().

README updated, but it will conflict after System Properties support is merged, so it has to be updated again later.

Basically the Environment is just a Map so I simply reused the ImmutableMap object.