### PR TITLE
Fix NPE reported by Coverity

### DIFF
--- a/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
@@ -88,7 +88,12 @@ public final class ArgsConfiguration implements Configuration {
                                     )
                     );
                 }
-                map.put(matcher.group(1), matcher.group(2).substring(1));
+
+                final String group1 = matcher.group(1);
+                final String group2 = matcher.group(2);
+                if (group1 != null && group2 != null) {
+                    map.put(group1, group2.substring(1));
+                }
             }
         }
         LOGGER.debug("Returning configuration map generated from command-line arguments.");


### PR DESCRIPTION
Recent Coverity scan reported an NPE in ArgsConfiguration for the second Matcher.group(). Added null checks for both groups before adding to the Map. Basically not possible to be null as an exception will be thrown if there is no match for both groups, but null checks will get rid of the Coverity defect.