### PR TITLE
Allow uppercase and periods in keys for ArgsConfiguration

### DIFF
--- a/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
@@ -76,7 +76,7 @@ public final class ArgsConfiguration implements Configuration {
         final Map<String, String> map = new HashMap<>();
 
         if (args.length != 0) {
-            final Pattern ptn = Pattern.compile("([a-z]+)(=.+)");
+            final Pattern ptn = Pattern.compile("([A-Za-z.]+)(=.+)");
             for (final String arg : args) {
                 final Matcher matcher = ptn.matcher(arg);
                 if (!matcher.matches() || matcher.group(1) == null | matcher.group(2) == null) {

--- a/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
@@ -74,6 +74,32 @@ public class ArgsConfigurationTest {
     }
 
     @Test
+    public void testCamelCaseArgs() {
+        String[] args = {
+                "exampleOption=value"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+        Map<String, String> map = Assertions.assertDoesNotThrow(config::asMap);
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey("exampleOption"));
+        Assertions.assertEquals("value", map.get("exampleOption"));
+    }
+
+    @Test
+    public void testDotArgs() {
+        String[] args = {
+                "example.option=value"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+        Map<String, String> map = Assertions.assertDoesNotThrow(config::asMap);
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey("example.option"));
+        Assertions.assertEquals("value", map.get("example.option"));
+    }
+
+    @Test
     public void testInvalidArgs() {
         String[] args = {
                 "foo", "bar"


### PR DESCRIPTION
Fixes #28 .

Adds the possibility to have uppercase letters and periods in keys when using cmd line arguments (or other string args).

Now allows:
"exampleKey=value"
"example.key=value"