### PR TITLE
Remove unnecessary equals and hashcode tests

### DIFF
--- a/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
@@ -135,58 +135,6 @@ public class ArgsConfigurationTest {
     }
 
     @Test
-    public void testEquals() {
-        String[] args = {
-                "foo=bar", "bar=foo"
-        };
-        ArgsConfiguration config = new ArgsConfiguration(args);
-
-        String[] args2 = {
-                "foo=bar", "bar=foo"
-        };
-        ArgsConfiguration config2 = new ArgsConfiguration(args2);
-
-        Assertions.assertDoesNotThrow(config::asMap);
-
-        Assertions.assertEquals(config, config2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        String[] args = {
-                "foo=bar", "bar=foo"
-        };
-        String[] args2 = {
-                ""
-        };
-
-        ArgsConfiguration config = new ArgsConfiguration(args);
-        ArgsConfiguration config2 = new ArgsConfiguration(args2);
-
-        Assertions.assertNotEquals(config, config2);
-    }
-
-    @Test
-    public void testHashCode() {
-        String[] args = {
-                "foo=bar", "bar=foo"
-        };
-        String[] args2 = {
-                "foo=bar", "bar=foo"
-        };
-        String[] args3 = {
-                ""
-        };
-
-        ArgsConfiguration config = new ArgsConfiguration(args);
-        ArgsConfiguration config2 = new ArgsConfiguration(args2);
-        ArgsConfiguration config3 = new ArgsConfiguration(args3);
-
-        Assertions.assertEquals(config.hashCode(), config2.hashCode());
-        Assertions.assertNotEquals(config.hashCode(), config3.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier.forClass(ArgsConfiguration.class).withNonnullFields("args").verify();
     }

--- a/src/test/java/com/teragrep/cnf_01/DefaultConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/DefaultConfigurationTest.java
@@ -93,58 +93,6 @@ public class DefaultConfigurationTest {
     }
 
     @Test
-    public void testEquals() {
-        PathConfiguration pathConfig1 = new PathConfiguration("src/test/resources/configuration.properties");
-        ImmutableMap<String, String> defaults1 = Assertions
-                .assertDoesNotThrow(() -> new ImmutabilitySupportedMap<>(pathConfig1.asMap()).toImmutableMap());
-        PathConfiguration pathConfig2 = new PathConfiguration("src/test/resources/configuration.properties");
-        ImmutableMap<String, String> defaults2 = Assertions
-                .assertDoesNotThrow(() -> new ImmutabilitySupportedMap<>(pathConfig2.asMap()).toImmutableMap());
-
-        DefaultConfiguration defaultConfiguration1 = new DefaultConfiguration(pathConfig1, defaults1);
-        DefaultConfiguration defaultConfiguration2 = new DefaultConfiguration(pathConfig2, defaults2);
-
-        defaultConfiguration1.asMap();
-
-        Assertions.assertEquals(defaultConfiguration1, defaultConfiguration2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        PathConfiguration pathConfig1 = new PathConfiguration("src/test/resources/configuration.properties");
-        ImmutableMap<String, String> defaults1 = Assertions
-                .assertDoesNotThrow(() -> new ImmutabilitySupportedMap<>(pathConfig1.asMap()).toImmutableMap());
-        PathConfiguration pathConfig2 = new PathConfiguration("invalid.path");
-        ImmutableMap<String, String> defaults2 = new ImmutabilitySupportedMap<String, String>(new HashMap<>())
-                .toImmutableMap();
-
-        DefaultConfiguration defaultConfiguration1 = new DefaultConfiguration(pathConfig1, defaults1);
-        DefaultConfiguration defaultConfiguration2 = new DefaultConfiguration(pathConfig2, defaults2);
-
-        Assertions.assertNotEquals(defaultConfiguration1, defaultConfiguration2);
-    }
-
-    @Test
-    public void testHashCode() {
-        PathConfiguration pathConfig1 = new PathConfiguration("src/test/resources/configuration.properties");
-        ImmutableMap<String, String> defaults1 = Assertions
-                .assertDoesNotThrow(() -> new ImmutabilitySupportedMap<>(pathConfig1.asMap()).toImmutableMap());
-        PathConfiguration pathConfig2 = new PathConfiguration("src/test/resources/configuration.properties");
-        ImmutableMap<String, String> defaults2 = Assertions
-                .assertDoesNotThrow(() -> new ImmutabilitySupportedMap<>(pathConfig2.asMap()).toImmutableMap());
-        PathConfiguration difPathConfig = new PathConfiguration("invalid.path");
-        ImmutableMap<String, String> difDefaults = new ImmutabilitySupportedMap<String, String>(new HashMap<>())
-                .toImmutableMap();
-
-        DefaultConfiguration defaultConfiguration1 = new DefaultConfiguration(pathConfig1, defaults1);
-        DefaultConfiguration defaultConfiguration2 = new DefaultConfiguration(pathConfig2, defaults2);
-        DefaultConfiguration difDefaultConfiguration = new DefaultConfiguration(difPathConfig, difDefaults);
-
-        Assertions.assertEquals(defaultConfiguration1.hashCode(), defaultConfiguration2.hashCode());
-        Assertions.assertNotEquals(defaultConfiguration1.hashCode(), difDefaultConfiguration.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier
                 .forClass(DefaultConfiguration.class)

--- a/src/test/java/com/teragrep/cnf_01/EnvironmentConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/EnvironmentConfigurationTest.java
@@ -92,55 +92,6 @@ public class EnvironmentConfigurationTest {
     }
 
     @Test
-    public void testEqualsEnvironment() {
-        EnvironmentConfiguration env1 = new EnvironmentConfiguration();
-        EnvironmentConfiguration env2 = new EnvironmentConfiguration();
-
-        env1.asMap();
-
-        Assertions.assertEquals(env1, env2);
-    }
-
-    @Test
-    public void testEqualsMap() {
-        Map<String, String> map1 = new HashMap<>();
-        map1.put("foo", "bar");
-        Map<String, String> map2 = new HashMap<>();
-        map2.put("foo", "bar");
-
-        EnvironmentConfiguration env1 = new EnvironmentConfiguration(map1);
-        EnvironmentConfiguration env2 = new EnvironmentConfiguration(map2);
-
-        env1.asMap();
-
-        Assertions.assertEquals(env1, env2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        Map<String, String> map = new HashMap<>();
-        map.put("foo", "bar");
-        EnvironmentConfiguration env1 = new EnvironmentConfiguration();
-        EnvironmentConfiguration env2 = new EnvironmentConfiguration(map);
-
-        Assertions.assertNotEquals(env1, env2);
-    }
-
-    @Test
-    public void testHashCode() {
-        Map<String, String> map1 = new HashMap<>();
-        map1.put("foo", "bar");
-        Map<String, String> map2 = new HashMap<>();
-        map2.put("foo", "bar");
-        EnvironmentConfiguration env1 = new EnvironmentConfiguration(map1);
-        EnvironmentConfiguration env2 = new EnvironmentConfiguration(map2);
-        EnvironmentConfiguration difEnv = new EnvironmentConfiguration();
-
-        Assertions.assertEquals(env1.hashCode(), env2.hashCode());
-        Assertions.assertNotEquals(env1.hashCode(), difEnv.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier.forClass(EnvironmentConfiguration.class).withNonnullFields("environment").verify();
     }

--- a/src/test/java/com/teragrep/cnf_01/ImmutabilitySupportedMapTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ImmutabilitySupportedMapTest.java
@@ -74,54 +74,6 @@ public class ImmutabilitySupportedMapTest {
     }
 
     @Test
-    public void testEquals() {
-        Map<String, String> map1 = new HashMap<>();
-        Map<String, String> map2 = new HashMap<>();
-        map1.put("foo", "bar");
-        map2.put("foo", "bar");
-
-        ImmutabilitySupportedMap<String, String> immutabilitySupportedMap1 = new ImmutabilitySupportedMap<>(map1);
-        ImmutabilitySupportedMap<String, String> immutabilitySupportedMap2 = new ImmutabilitySupportedMap<>(map2);
-
-        // It's a Map decorator so it is mutable, but the new function toImmutableMap shouldn't mutate the object
-        immutabilitySupportedMap1.toImmutableMap();
-
-        Assertions.assertEquals(immutabilitySupportedMap1, immutabilitySupportedMap2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        Map<String, String> map1 = new HashMap<>();
-        Map<String, String> map2 = new HashMap<>();
-        Map<String, String> difMap = new HashMap<>();
-        map1.put("foo", "bar");
-        map2.put("foo", "bar");
-
-        ImmutabilitySupportedMap<String, String> immutabilitySupportedMap1 = new ImmutabilitySupportedMap<>(map1);
-        ImmutabilitySupportedMap<String, String> immutabilitySupportedMap2 = new ImmutabilitySupportedMap<>(map2);
-        ImmutabilitySupportedMap<String, String> difImmutabilitySupportedMap = new ImmutabilitySupportedMap<>(difMap);
-
-        Assertions.assertEquals(immutabilitySupportedMap1, immutabilitySupportedMap2);
-        Assertions.assertNotEquals(immutabilitySupportedMap1, difImmutabilitySupportedMap);
-    }
-
-    @Test
-    public void testHashCode() {
-        Map<String, String> map1 = new HashMap<>();
-        Map<String, String> map2 = new HashMap<>();
-        Map<String, String> difMap = new HashMap<>();
-        map1.put("foo", "bar");
-        map2.put("foo", "bar");
-
-        ImmutabilitySupportedMap<String, String> immutabilitySupportedMap1 = new ImmutabilitySupportedMap<>(map1);
-        ImmutabilitySupportedMap<String, String> immutabilitySupportedMap2 = new ImmutabilitySupportedMap<>(map2);
-        ImmutabilitySupportedMap<String, String> difImmutabilitySupportedMap = new ImmutabilitySupportedMap<>(difMap);
-
-        Assertions.assertEquals(immutabilitySupportedMap1.hashCode(), immutabilitySupportedMap2.hashCode());
-        Assertions.assertNotEquals(immutabilitySupportedMap1.hashCode(), difImmutabilitySupportedMap.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier.forClass(ImmutabilitySupportedMap.class).withNonnullFields("map").verify();
     }

--- a/src/test/java/com/teragrep/cnf_01/ImmutableMapTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ImmutableMapTest.java
@@ -73,49 +73,6 @@ public class ImmutableMapTest {
     }
 
     @Test
-    public void testEquals() {
-        Map<String, String> map1 = new HashMap<>();
-        map1.put("foo", "bar");
-        Map<String, String> map2 = new HashMap<>();
-        map2.put("foo", "bar");
-
-        ImmutableMap<String, String> immutableMap1 = new ImmutableMap<>(map1);
-        ImmutableMap<String, String> immutableMap2 = new ImmutableMap<>(map2);
-
-        immutableMap1.map();
-
-        Assertions.assertEquals(immutableMap1, immutableMap2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        Map<String, String> map1 = new HashMap<>();
-        map1.put("foo", "bar");
-        Map<String, String> map2 = new HashMap<>();
-
-        ImmutableMap<String, String> immutableMap1 = new ImmutableMap<>(map1);
-        ImmutableMap<String, String> immutableMap2 = new ImmutableMap<>(map2);
-
-        Assertions.assertNotEquals(immutableMap1, immutableMap2);
-    }
-
-    @Test
-    public void testHashCode() {
-        Map<String, String> map1 = new HashMap<>();
-        map1.put("foo", "bar");
-        Map<String, String> map2 = new HashMap<>();
-        map2.put("foo", "bar");
-        Map<String, String> map3 = new HashMap<>();
-
-        ImmutableMap<String, String> immutableMap1 = new ImmutableMap<>(map1);
-        ImmutableMap<String, String> immutableMap2 = new ImmutableMap<>(map2);
-        ImmutableMap<String, String> difImmutableMap = new ImmutableMap<>(map3);
-
-        Assertions.assertEquals(immutableMap1.hashCode(), immutableMap2.hashCode());
-        Assertions.assertNotEquals(immutableMap1.hashCode(), difImmutableMap.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier.forClass(ImmutableMap.class).withNonnullFields("map").verify();
     }

--- a/src/test/java/com/teragrep/cnf_01/PathConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/PathConfigurationTest.java
@@ -73,33 +73,6 @@ public class PathConfigurationTest {
     }
 
     @Test
-    public void testEquals() {
-        PathConfiguration config1 = new PathConfiguration("src/test/resources/configuration.properties");
-        PathConfiguration config2 = new PathConfiguration("src/test/resources/configuration.properties");
-
-        Assertions.assertDoesNotThrow(config1::asMap);
-        Assertions.assertEquals(config1, config2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        PathConfiguration config1 = new PathConfiguration("src/test/resources/configuration.properties");
-        PathConfiguration config2 = new PathConfiguration("invalid.path");
-
-        Assertions.assertNotEquals(config1, config2);
-    }
-
-    @Test
-    public void testHashCode() {
-        PathConfiguration config1 = new PathConfiguration("src/test/resources/configuration.properties");
-        PathConfiguration config2 = new PathConfiguration("src/test/resources/configuration.properties");
-        PathConfiguration difConfig = new PathConfiguration("invalid.path");
-
-        Assertions.assertEquals(config1.hashCode(), config2.hashCode());
-        Assertions.assertNotEquals(config1.hashCode(), difConfig.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier.forClass(PathConfiguration.class).withNonnullFields("file").verify();
     }

--- a/src/test/java/com/teragrep/cnf_01/PropertiesConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/PropertiesConfigurationTest.java
@@ -98,60 +98,6 @@ public class PropertiesConfigurationTest {
     }
 
     @Test
-    public void testEqualsWithSystemProperties() {
-        PropertiesConfiguration config1 = new PropertiesConfiguration();
-        PropertiesConfiguration config2 = new PropertiesConfiguration();
-
-        config1.asMap();
-        Assertions.assertEquals(config1, config2);
-    }
-
-    @Test
-    public void testEqualsWithProperties() {
-        Properties properties1 = new Properties();
-        properties1.put("foo", "bar");
-
-        Properties properties2 = new Properties();
-        properties2.put("foo", "bar");
-
-        PropertiesConfiguration config1 = new PropertiesConfiguration(properties1);
-        // modifying properties1 doesn't modify immutable PropertiesConfiguration
-        properties1.put("bar", "foo");
-
-        PropertiesConfiguration config2 = new PropertiesConfiguration(properties2);
-
-        config1.asMap();
-        Assertions.assertEquals(config1, config2);
-    }
-
-    @Test
-    public void testNotEquals() {
-        Properties properties = new Properties();
-        properties.put("foo", "bar");
-
-        PropertiesConfiguration config1 = new PropertiesConfiguration();
-        PropertiesConfiguration config2 = new PropertiesConfiguration(properties);
-
-        Assertions.assertNotEquals(config1, config2);
-    }
-
-    @Test
-    public void testHashCode() {
-        Properties properties1 = new Properties();
-        properties1.put("foo", "bar");
-
-        Properties properties2 = new Properties();
-        properties2.put("foo", "bar");
-
-        PropertiesConfiguration config1 = new PropertiesConfiguration(properties1);
-        PropertiesConfiguration config2 = new PropertiesConfiguration(properties2);
-        PropertiesConfiguration difConfig = new PropertiesConfiguration();
-
-        Assertions.assertEquals(config1.hashCode(), config2.hashCode());
-        Assertions.assertNotEquals(config1.hashCode(), difConfig.hashCode());
-    }
-
-    @Test
     public void testEqualsVerifier() {
         EqualsVerifier.forClass(PropertiesConfiguration.class).withNonnullFields("configuration").verify();
     }


### PR DESCRIPTION
Fixes #33 .

Coverity flagged an equality test in ImmutableMapTest.java because of an unnecessary method call. Removing just that line makes the equality test quite unnecessary itself as the function call was there to check for side-effects.

My thought process here:

1. Remove the line of code.
2. Remove the whole test as it's useless now. There is equalsverifier tests anyway!
3. Why not remove all manual equals tests to remove clutter, equalsverifier tool is used anyway.

Added bonus:
Coverity won't flag other tests in the future, because many other equality tests had similar unnecessary function calls but for some reason they were not flagged yet.

**TLDR**:
Equalsverifier is used in the project, so manual equality tests are not necessary. Coverity had flagged one of the manual tests, might flag more later.