### PR TITLE
Allow hyphen and underscore in keys in ArgsConfiguration

### DIFF
--- a/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
@@ -69,21 +69,21 @@ public final class ArgsConfiguration implements Configuration {
      * Produces a Map of configurations from the args.
      *
      * @return immutable map of the args
-     * @throws ConfigurationException If the args are not given in the format of this regex: ([a-z]+)(=.+)
+     * @throws ConfigurationException If the args are not given in the format of this regex: ([A-Za-z.\-_]+)(=.+)
      */
     @Override
     public Map<String, String> asMap() throws ConfigurationException {
         final Map<String, String> map = new HashMap<>();
 
         if (args.length != 0) {
-            final Pattern ptn = Pattern.compile("([A-Za-z.]+)(=.+)");
+            final Pattern ptn = Pattern.compile("([A-Za-z.\\-_]+)(=.+)");
             for (final String arg : args) {
                 final Matcher matcher = ptn.matcher(arg);
                 if (!matcher.matches() || matcher.group(1) == null | matcher.group(2) == null) {
                     throw new ConfigurationException(
                             String
                                     .format(
-                                            "Can't parse argument '%s'. Args have to be given in \"key=value\" format.",
+                                            "Can't parse argument '%s'. It might contain an unsupported character or is not given in \"key=value\" format.",
                                             arg
                                     )
                     );

--- a/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
@@ -100,6 +100,32 @@ public class ArgsConfigurationTest {
     }
 
     @Test
+    public void testUnderscoreArgs() {
+        String[] args = {
+                "example_option=value"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+        Map<String, String> map = Assertions.assertDoesNotThrow(config::asMap);
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey("example_option"));
+        Assertions.assertEquals("value", map.get("example_option"));
+    }
+
+    @Test
+    public void testHyphenArgs() {
+        String[] args = {
+                "example-option=value"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+        Map<String, String> map = Assertions.assertDoesNotThrow(config::asMap);
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey("example-option"));
+        Assertions.assertEquals("value", map.get("example-option"));
+    }
+
+    @Test
     public void testInvalidArgs() {
         String[] args = {
                 "foo", "bar"
@@ -111,7 +137,7 @@ public class ArgsConfigurationTest {
 
         Assertions
                 .assertEquals(
-                        "Can't parse argument 'foo'. Args have to be given in \"key=value\" format.",
+                        "Can't parse argument 'foo'. It might contain an unsupported character or is not given in \"key=value\" format.",
                         exception.getMessage()
                 );
     }


### PR DESCRIPTION
Fixes #36 .

The configurations for String[] args have to be given in "key=value" format. Keys supported letters and a dot before. Reworked it so that hyphens and underscore are also supported.

Updated the javadoc for the regex and made the exception message a bit more clear: it now informs about a possible illegal character in the configurations as well.