### PR TITLE
Allow any key in ArgsConfiguration

### DIFF
--- a/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
@@ -76,7 +76,7 @@ public final class ArgsConfiguration implements Configuration {
         final Map<String, String> map = new HashMap<>();
 
         if (args.length != 0) {
-            final Pattern ptn = Pattern.compile("(.+)(=.+)");
+            final Pattern ptn = Pattern.compile("((?:\\\\=|[^=])+)=((?:\\\\=|[^=])+)");
             for (final String arg : args) {
                 final Matcher matcher = ptn.matcher(arg);
                 if (!matcher.matches() || matcher.group(1) == null | matcher.group(2) == null) {
@@ -89,7 +89,10 @@ public final class ArgsConfiguration implements Configuration {
                     );
                 }
 
-                map.put(matcher.group(1), matcher.group(2).substring(1));
+                // unescape equal signs
+                final String key = matcher.group(1).replace("\\=", "=");
+                final String value = matcher.group(2).replace("\\=", "=");
+                map.put(key, value);
             }
         }
         LOGGER.debug("Returning configuration map generated from command-line arguments.");

--- a/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
+++ b/src/main/java/com/teragrep/cnf_01/ArgsConfiguration.java
@@ -69,21 +69,21 @@ public final class ArgsConfiguration implements Configuration {
      * Produces a Map of configurations from the args.
      *
      * @return immutable map of the args
-     * @throws ConfigurationException If the args are not given in the format of this regex: ([A-Za-z.\-_]+)(=.+)
+     * @throws ConfigurationException If the args are not given in the 'key=value' format.
      */
     @Override
     public Map<String, String> asMap() throws ConfigurationException {
         final Map<String, String> map = new HashMap<>();
 
         if (args.length != 0) {
-            final Pattern ptn = Pattern.compile("([A-Za-z.\\-_]+)(=.+)");
+            final Pattern ptn = Pattern.compile("(.+)(=.+)");
             for (final String arg : args) {
                 final Matcher matcher = ptn.matcher(arg);
                 if (!matcher.matches() || matcher.group(1) == null | matcher.group(2) == null) {
                     throw new ConfigurationException(
                             String
                                     .format(
-                                            "Can't parse argument '%s'. It might contain an unsupported character or is not given in \"key=value\" format.",
+                                            "Can't parse argument '%s'. Arguments must be given in \"key=value\" format.",
                                             arg
                                     )
                     );

--- a/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
@@ -126,6 +126,48 @@ public class ArgsConfigurationTest {
     }
 
     @Test
+    public void testEscapeCharacterArgs() {
+        String[] args = {
+                "fo\\o=ba\\a\\a\\r"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+        Map<String, String> map = Assertions.assertDoesNotThrow(config::asMap);
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey("fo\\o"));
+        Assertions.assertEquals("ba\\a\\a\\r", map.get("fo\\o"));
+    }
+
+    @Test
+    public void testMultipleEqualsEscapedArgs() {
+        String[] args = {
+                "foo=b\\=ar"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+        Map<String, String> map = Assertions.assertDoesNotThrow(config::asMap);
+
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertTrue(map.containsKey("foo"));
+        Assertions.assertEquals("b=ar", map.get("foo"));
+    }
+
+    @Test
+    public void testMultipleEqualsArgs() {
+        String[] args = {
+                "foo=b=ar"
+        };
+        ArgsConfiguration config = new ArgsConfiguration(args);
+
+        ConfigurationException exception = Assertions.assertThrows(ConfigurationException.class, config::asMap);
+
+        Assertions
+                .assertEquals(
+                        "Can't parse argument 'foo=b=ar'. Arguments must be given in \"key=value\" format.",
+                        exception.getMessage()
+                );
+    }
+
+    @Test
     public void testInvalidArgs() {
         String[] args = {
                 "foo", "bar"

--- a/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
+++ b/src/test/java/com/teragrep/cnf_01/ArgsConfigurationTest.java
@@ -137,7 +137,24 @@ public class ArgsConfigurationTest {
 
         Assertions
                 .assertEquals(
-                        "Can't parse argument 'foo'. It might contain an unsupported character or is not given in \"key=value\" format.",
+                        "Can't parse argument 'foo'. Arguments must be given in \"key=value\" format.",
+                        exception.getMessage()
+                );
+    }
+
+    @Test
+    public void testNoKeyNoValue() {
+        String[] args = {
+                "="
+        };
+
+        ArgsConfiguration config = new ArgsConfiguration(args);
+
+        ConfigurationException exception = Assertions.assertThrows(ConfigurationException.class, config::asMap);
+
+        Assertions
+                .assertEquals(
+                        "Can't parse argument '='. Arguments must be given in \"key=value\" format.",
                         exception.getMessage()
                 );
     }


### PR DESCRIPTION
Fixes #40 .

Previously ArgsConfiguration supported a selected set of characters in the key and any characters in the value of the argument. This had led to many PRs adding more supported characters to the regex as they've been needed.

This PR introduces a regex just checks that the argument is in the "key=value" format (in other words, checks that there is something before and after an equals sign). After evaluating the object, there really is no need to check for illegal characters and the user might have specific needs for the key anyways which is not for the object to restrict.

Added a test for the case where an argument is just the equals sign.